### PR TITLE
Added lockableRotation option

### DIFF
--- a/src/main/java/com/simibubi/worldshape/structure/WStructure.java
+++ b/src/main/java/com/simibubi/worldshape/structure/WStructure.java
@@ -12,6 +12,7 @@ import com.simibubi.worldshape.foundation.Pair;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.Rotation;
 import net.minecraft.util.SharedSeedRandom;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
@@ -162,8 +163,9 @@ public class WStructure extends Structure<NoFeatureConfig> {
 			MutableBoolean firstPiece = new MutableBoolean(true);
 			IPieceFactory factory = (m, j, p, groundDelta, r, bb) -> {
 				int resultDelta = firstPiece.booleanValue() ? groundDelta + terraformOffset : groundDelta;
+				Rotation rot = firstPiece.booleanValue() && placement.lockRotation ? Rotation.NONE : r;
 				firstPiece.setFalse();
-				return new AbstractVillagePiece(m, j, p, resultDelta, r, bb);
+				return new AbstractVillagePiece(m, j, p, resultDelta, rot, bb);
 			};
 
 			JigsawManager.addPieces(dynamicRegistryManager, jigsawConfig, factory, chunkGenerator, templateManagerIn,

--- a/src/main/java/com/simibubi/worldshape/structure/WStructurePlacement.java
+++ b/src/main/java/com/simibubi/worldshape/structure/WStructurePlacement.java
@@ -23,9 +23,10 @@ public abstract class WStructurePlacement {
 	int minY;
 	int maxY;
 	int surfaceOffset;
+	boolean lockRotation;
 	boolean needsWater;
 	Optional<Integer> terraform;
-	
+
 	public static WStructurePlacement get(ResourceLocation id, JsonElement json) {
 		if (json.isJsonObject()) {
 			JsonObject jo = json.getAsJsonObject();
@@ -46,6 +47,7 @@ public abstract class WStructurePlacement {
 		maxY = JSONUtils.getAsInt(json, "maxY", 256);
 		minY = JSONUtils.getAsInt(json, "minY", 0);
 		surfaceOffset = JSONUtils.getAsInt(json, "offset", 0);
+		lockRotation = JSONUtils.getAsBoolean(json, "lockRotation", false);
 		needsWater = JSONUtils.getAsBoolean(json, "fluidSurface", false);
 		terraform = Optional.ofNullable(json.has("terraform") ? JSONUtils.getAsInt(json, "terraform", -1) : null);
 		return this;
@@ -75,6 +77,10 @@ public abstract class WStructurePlacement {
 
 	public boolean fluidSurface() {
 		return needsWater;
+	}
+
+	public boolean lockRotation() {
+		return lockRotation;
 	}
 
 	public final Optional<Integer> determineY(ChunkGenerator generator, IBlockReader reader, SharedSeedRandom random,


### PR DESCRIPTION
I added a small option that can be used inside of the `placement` section of the `spawn_structures.json` file to prevent structure rotations. This is useful for structures that use non-rotatable blocks, such as CB-Multipart. (I was having quite a bit of an issue trying to get those structures to spawn correctly. Locking the rotation makes things so much easier.)

This implementation only locks the first piece of the jigsaw, as locking the rotation of the nested elements is not possible. But this is acceptable as the rotation for those can easily be controlled by the placement of the Jigsaw blocks inside of the structure, naturally.